### PR TITLE
String.format Hatası

### DIFF
--- a/src/test/java/MainTest.java
+++ b/src/test/java/MainTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.lang.reflect.Field;
+import java.util.Locale;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
@@ -58,7 +59,7 @@ public class MainTest {
     @DisplayName("getArea methodu Circle sınıfında doğru çalışıyor mu?")
     @Test
     public void testGetArea() throws NoSuchFieldException {
-        assertEquals(String.format("%.2f", circle.getArea()), "12.57");
+        assertEquals(String.format(Locale.ENGLISH, "%.2f", circle.getArea()), "12.57");
     }
 
     @DisplayName("Circle sınıf değişkenleri doğru access modifier a sahip mi ?")
@@ -78,7 +79,7 @@ public class MainTest {
     @DisplayName("getVolume methodu doğru çalışıyor mu?")
     @Test
     public void testGetVolume() throws NoSuchFieldException {
-        assertEquals(String.format("%.2f", cylinder.getVolume()), "25.13");
+        assertEquals(String.format(Locale.ENGLISH, "%.2f", cylinder.getVolume()), "25.13");
     }
 
     @DisplayName("Rectangle sınıf değişkenleri doğru access modifier a sahip mi ?")
@@ -100,7 +101,7 @@ public class MainTest {
     @DisplayName("getArea methodu Rectangle sınıfında doğru çalışıyor mu?")
     @Test
     public void testGetAreaRectangle() throws NoSuchFieldException {
-        assertEquals(String.format("%.2f", rectangle.getArea()), "2.00");
+        assertEquals(String.format(Locale.ENGLISH, "%.2f", rectangle.getArea()), "2.00");
     }
 
     @DisplayName("Cuboid sınıf değişkenleri doğru access modifier a sahip mi ?")
@@ -120,7 +121,7 @@ public class MainTest {
     @DisplayName("getVolume methodu Cuboid sınıfında doğru çalışıyor mu?")
     @Test
     public void testGetVolumeRectangle() throws NoSuchFieldException {
-        assertEquals(String.format("%.2f", cuboid.getVolume()), "6.00");
+        assertEquals(String.format(Locale.ENGLISH, "%.2f", cuboid.getVolume()), "6.00");
     }
 
     @DisplayName("Employee sınıf değişkenleri doğru access modifier a sahip mi ?")


### PR DESCRIPTION
String.format fonksiyonu, varsayılan dile ya da bölgeye göre formatladığı için ve Türkiye'de ondalıklı sayılar virgül ile yazıldığı için sayıları "x.y" yerine "x,y" olarak formatlıyor. Bu yüzden dört test kendi bilgisayarımda çalıştırıldığımda geçilmiyor.

Not: Bu testler GitHub Actions'ta geçiyor, sorun sadece kendi bilgisayarımda testi çalıştırdığımda ortaya çıkıyor.